### PR TITLE
Update docs and roadmap to document status filtering changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,15 +190,16 @@ $ sudo linux-maint status
 totals: CRIT=1 WARN=2 UNKNOWN=0 SKIP=1 OK=14
 
 problems:
-CRIT ntp_drift_monitor reason=ntp_drift_high
-WARN patch_monitor reason=security_updates_pending
-SKIP backup_check reason=missing_targets_file
+CRIT ntp_drift_monitor host=server-a reason=ntp_drift_high
+WARN patch_monitor host=server-a reason=security_updates_pending
+SKIP backup_check host=server-a reason=missing_targets_file
 ```
 
 Tips:
 - `sudo linux-maint status --verbose` for raw summary lines
 - `sudo linux-maint diff` to show changes since the last run
 - `sudo linux-maint status --problems 100` to list more problems (max 100)
+- `sudo linux-maint status --host web --monitor service --only WARN` to narrow noisy output quickly
 
 - **Exit codes** (wrapper): `0 OK`, `1 WARN`, `2 CRIT`, `3 UNKNOWN`
 - Logs:

--- a/ToDoList.txt
+++ b/ToDoList.txt
@@ -83,3 +83,19 @@
 
 **Verify**:
 - Running twice is safe.
+
+### P1.1 Status filtering: support regex / exact-match mode (NOT DONE)
+**Why**: current `--host` and `--monitor` use substring matching only; operators may want exact or regex matching for stricter automation.
+
+**Where**:
+- `bin/linux-maint`
+- `docs/reference.md`
+- `tests/status_filters_test.sh`
+
+**Acceptance**:
+- Add optional status flags for explicit match modes (for example `--host-regex`, `--monitor-regex`, or `--exact`).
+- Keep existing substring behavior fully backward-compatible.
+- JSON and compact outputs must apply the same matching semantics.
+
+**Verify**:
+- Extend `tests/status_filters_test.sh` with positive + negative cases for the new mode(s).

--- a/bin/linux-maint
+++ b/bin/linux-maint
@@ -348,6 +348,8 @@ case "$cmd" in
     PROB_N=20
     JSON=0
     LAST_N=0
+    HOST_FILTER=""
+    MONITOR_FILTER=""
 
 
     while [[ $# -gt 0 ]]; do
@@ -357,10 +359,12 @@ case "$cmd" in
         --verbose) VERBOSE=1; shift 1;;
         --quiet) QUIET=1; shift 1;;
         --json) JSON=1; shift 1;;
+        --host) HOST_FILTER="$2"; shift 2;;
+        --monitor) MONITOR_FILTER="$2"; shift 2;;
         --problems) PROB_N="$2"; shift 2;;
         --last) LAST_N="$2"; shift 2;;
         -h|--help)
-          echo "Usage: linux-maint status [--only OK|WARN|CRIT|UNKNOWN|SKIP] [--tail N] [--verbose] [--quiet] [--json] [--problems N (max 100)] [--last N]"
+          echo "Usage: linux-maint status [--only OK|WARN|CRIT|UNKNOWN|SKIP] [--host PATTERN] [--monitor PATTERN] [--tail N] [--verbose] [--quiet] [--json] [--problems N (max 100)] [--last N]"
           exit 0;;
         *) echo "Unknown status flag: $1" >&2; exit 2;;
       esac
@@ -410,10 +414,10 @@ case "$cmd" in
         summary_file="$INST_SUMMARY_LATEST"
       fi
 
-      python3 - "$MODE" "$status_file" "$summary_file" "$ONLY" "$PROB_N" <<'PY'
+      python3 - "$MODE" "$status_file" "$summary_file" "$ONLY" "$PROB_N" "$HOST_FILTER" "$MONITOR_FILTER" <<'PY'
 import json, os, re, sys
 
-mode, status_path, summary_path, only, limit = sys.argv[1:6]
+mode, status_path, summary_path, only, limit, host_filter, monitor_filter = sys.argv[1:8]
 limit=int(limit)
 
 def read_kv(path):
@@ -444,13 +448,19 @@ if summary_path and os.path.exists(summary_path):
             if not line.startswith('monitor='):
                 continue
             st=get_kv(line,'status') or 'UNKNOWN'
+            host=get_kv(line,'host') or ''
+            monitor=get_kv(line,'monitor') or ''
             if only and st != only:
+                continue
+            if host_filter and host_filter not in host:
+                continue
+            if monitor_filter and monitor_filter not in monitor:
                 continue
             counts[st]=counts.get(st,0)+1
             if st!='OK':
-                mon=get_kv(line,'monitor') or 'unknown_monitor'
+                mon=monitor or 'unknown_monitor'
                 reason=get_kv(line,'reason')
-                entry={'status':st,'monitor':mon}
+                entry={'status':st,'monitor':mon,'host':host}
                 if reason:
                     entry['reason']=reason
                 problems.append(entry)
@@ -519,12 +529,45 @@ PY
     if [[ -f "$summary_file" ]]; then
       if [[ "$VERBOSE" -eq 1 ]]; then
         echo "(verbose; last $TAIL_N lines from: $summary_file)"
-        tail -n "$TAIL_N" "$summary_file" || true
+        if [[ -n "$ONLY" || -n "$HOST_FILTER" || -n "$MONITOR_FILTER" ]]; then
+          python3 - "$summary_file" "$TAIL_N" "$ONLY" "$HOST_FILTER" "$MONITOR_FILTER" <<'PY'
+import re, sys
+
+path, tail_n, only, host_filter, monitor_filter = sys.argv[1:6]
+tail_n=int(tail_n)
+
+def get_kv(line, key):
+    m=re.search(rf"\b{re.escape(key)}=([^ ]+)", line)
+    return m.group(1) if m else None
+
+matched=[]
+with open(path, 'r', encoding='utf-8', errors='ignore') as f:
+    for line in f:
+        line=line.strip()
+        if not line.startswith('monitor='):
+            continue
+        st=get_kv(line,'status') or 'UNKNOWN'
+        host=get_kv(line,'host') or ''
+        monitor=get_kv(line,'monitor') or ''
+        if only and st != only:
+            continue
+        if host_filter and host_filter not in host:
+            continue
+        if monitor_filter and monitor_filter not in monitor:
+            continue
+        matched.append(line)
+
+for line in matched[-tail_n:]:
+    print(line)
+PY
+        else
+          tail -n "$TAIL_N" "$summary_file" || true
+        fi
       else
         [[ "$QUIET" -eq 0 ]] && echo "(from: $summary_file)"
-        python3 - "$summary_file" "$ONLY" "$PROB_N" <<'PY'
+        python3 - "$summary_file" "$ONLY" "$PROB_N" "$HOST_FILTER" "$MONITOR_FILTER" <<'PY'
 import re, sys
-path, only, limit = sys.argv[1:4]
+path, only, limit, host_filter, monitor_filter = sys.argv[1:6]
 limit=int(limit)
 
 # Example line:
@@ -542,18 +585,24 @@ with open(path, 'r', encoding='utf-8', errors='ignore') as f:
         if not line:
             continue
         st=get_kv(line,'status') or 'UNKNOWN'
+        host=get_kv(line,'host') or ''
+        monitor=get_kv(line,'monitor') or ''
         if only and st != only:
+            continue
+        if host_filter and host_filter not in host:
+            continue
+        if monitor_filter and monitor_filter not in monitor:
             continue
         counts[st]=counts.get(st,0)+1
         if st == 'OK':
             continue
-        mon=get_kv(line,'monitor') or 'unknown_monitor'
+        mon=monitor or 'unknown_monitor'
         reason=get_kv(line,'reason')
         # Format D: "STATUS monitor reason=..." (reason only if exists)
         if reason:
-            problems.append(f"{st} {mon} reason={reason}")
+            problems.append(f"{st} {mon} host={host} reason={reason}")
         else:
-            problems.append(f"{st} {mon}")
+            problems.append(f"{st} {mon} host={host}")
 
 order=['CRIT','WARN','UNKNOWN','SKIP','OK']
 print('totals: ' + ' '.join(f"{k}={counts.get(k,0)}" for k in order))

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -17,6 +17,9 @@ sudo linux-maint status --problems 100
 # Raw summary lines
 sudo linux-maint status --verbose
 
+# Filter by host/monitor/status
+sudo linux-maint status --host web --monitor service --only WARN
+
 # Diff since last run
 sudo linux-maint diff
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -298,6 +298,8 @@ Status flags (installed mode):
 - `--verbose` — show raw summary lines
 - `--problems N` — number of problem entries to display (default 20, max 100)
 - `--only OK|WARN|CRIT|UNKNOWN|SKIP` — filter by status
+- `--host PATTERN` — show only entries where `host` contains `PATTERN`
+- `--monitor PATTERN` — show only entries where `monitor` contains `PATTERN`
 
 
 - `linux-maint logs [n]` *(root required)*: tail the latest wrapper log (default `n=200`).

--- a/summarize.txt
+++ b/summarize.txt
@@ -356,3 +356,9 @@ echo "##active_line4##"
 
 2026-02-13
 - docs: add docs/INDEX.md and link it (and key docs) prominently from README for GitHub readability.
+
+## 2026-02-15
+- cli/status: add `--host PATTERN` and `--monitor PATTERN` filters for compact, verbose, and JSON status output.
+- cli/status: include `host=...` context in compact problem lines and JSON problem entries to improve triage/automation readability.
+- tests: add `tests/status_filters_test.sh` regression coverage for filtered compact + JSON outputs.
+- docs: update `README.md`, `docs/reference.md`, and `docs/QUICK_REFERENCE.md` with new status filtering examples/flags.

--- a/tests/status_filters_test.sh
+++ b/tests/status_filters_test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+LM="$ROOT_DIR/bin/linux-maint"
+LOG_DIR="$ROOT_DIR/.logs"
+mkdir -p "$LOG_DIR"
+
+SUMMARY_FILE="$LOG_DIR/full_health_monitor_summary_latest.log"
+STATUS_FILE="$LOG_DIR/last_status_full"
+
+bak_summary="$(mktemp /tmp/lm_summary_bak.XXXXXX)"
+bak_status="$(mktemp /tmp/lm_status_bak.XXXXXX)"
+had_summary=0
+had_status=0
+
+if [[ -f "$SUMMARY_FILE" ]]; then
+  cp "$SUMMARY_FILE" "$bak_summary"
+  had_summary=1
+fi
+if [[ -f "$STATUS_FILE" ]]; then
+  cp "$STATUS_FILE" "$bak_status"
+  had_status=1
+fi
+
+cleanup(){
+  if [[ "$had_summary" -eq 1 ]]; then
+    cp "$bak_summary" "$SUMMARY_FILE"
+  else
+    rm -f "$SUMMARY_FILE"
+  fi
+  if [[ "$had_status" -eq 1 ]]; then
+    cp "$bak_status" "$STATUS_FILE"
+  else
+    rm -f "$STATUS_FILE"
+  fi
+  rm -f "$bak_summary" "$bak_status"
+}
+trap cleanup EXIT
+
+cat > "$STATUS_FILE" <<'S'
+status=warn
+timestamp=2026-02-15T00:00:00+00:00
+S
+
+cat > "$SUMMARY_FILE" <<'S'
+monitor=service_monitor host=web-1 status=WARN reason=failed_units
+monitor=service_monitor host=db-1 status=OK
+monitor=network_monitor host=web-1 status=CRIT reason=http_down
+monitor=backup_check host=backup-1 status=SKIP reason=missing_targets_file
+S
+
+out="$(bash "$LM" status --quiet --host web --monitor service --only WARN)"
+echo "$out" | grep -q 'totals: CRIT=0 WARN=1 UNKNOWN=0 SKIP=0 OK=0'
+echo "$out" | grep -q 'WARN service_monitor host=web-1 reason=failed_units'
+
+json_out="$(bash "$LM" status --json --host web --monitor service --only WARN)"
+printf '%s' "$json_out" | python3 -c 'import json,sys; o=json.load(sys.stdin); assert o["totals"]["WARN"]==1; assert o["totals"]["CRIT"]==0; assert len(o["problems"])==1; p=o["problems"][0]; assert p["monitor"]=="service_monitor"; assert p["host"]=="web-1"'
+
+echo "status filters ok"


### PR DESCRIPTION
### Motivation
- Capture and document the recently added `linux-maint status` filtering capabilities so repository metadata reflects delivered behavior.
- Make compact and JSON status outputs actionable by surfacing `host=` context for filtered results.
- Satisfy the repo policy that requires updating `summarize.txt` and/or `ToDoList.txt` whenever code changes are introduced.

### Description
- Add `--host PATTERN` and `--monitor PATTERN` flags to `bin/linux-maint` and wire them into both compact, verbose (tail) and JSON code paths to filter summary lines.
- Include `host` in compact problem lines and in JSON `problems` entries so filtered results include target context for triage and automation.
- Update docs: `README.md`, `docs/QUICK_REFERENCE.md`, and `docs/reference.md` with usage examples and flag descriptions for the new filters.
- Add regression test `tests/status_filters_test.sh` that seeds summary/status fixtures and verifies both compact and JSON filtered output behavior, and update `summarize.txt` and `ToDoList.txt` to document the change and add a follow-up roadmap item for regex/exact-match filter modes.

### Testing
- Ran `bash tests/status_filters_test.sh`, which completed successfully (`status filters ok`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69916506937c83328979d35edcc5db0c)