### PR TITLE
Reduce preflight summary noise and add single-line contract coverage

### DIFF
--- a/ToDoList.txt
+++ b/ToDoList.txt
@@ -75,7 +75,7 @@ This is the single backlog source of truth.
 
 ---
 
-### P0.3 [contract] Preflight summary-line noise reduction (NOT DONE)
+### P0.3 [contract] Preflight summary-line noise reduction (DONE 2026-02-16)
 **Why**: preflight currently emits multiple summary lines from optional dependency checks, making contract output noisy.
 
 **Where**:
@@ -88,6 +88,8 @@ This is the single backlog source of truth.
 
 **Verify**:
 - Extend `tests/summary_contract.sh` / preflight-focused test coverage.
+- ✅ Implemented: preflight no longer emits per-dependency summary lines; dependency details now go to the monitor log and a single actionable `monitor=preflight_check` summary line is emitted.
+- ✅ Coverage: extended `tests/preflight_missing_ssh_test.sh` to assert single-line summary output on missing required dependency paths.
 
 ---
 

--- a/monitors/preflight_check.sh
+++ b/monitors/preflight_check.sh
@@ -22,21 +22,6 @@ LM_LOGFILE="${LM_LOGFILE:-/var/log/preflight_check.log}"
 
 lm_require_singleton "preflight_check"
 
-# Dependency checks (local runner)
-lm_require_cmd "preflight_check" "localhost" awk || true
-lm_require_cmd "preflight_check" "localhost" sed || true
-lm_require_cmd "preflight_check" "localhost" grep || true
-lm_require_cmd "preflight_check" "localhost" df || true
-lm_require_cmd "preflight_check" "localhost" ssh || true
-lm_require_cmd "preflight_check" "localhost" openssl --optional || true
-lm_require_cmd "preflight_check" "localhost" ss --optional || true
-lm_require_cmd "preflight_check" "localhost" netstat --optional || true
-lm_require_cmd "preflight_check" "localhost" journalctl --optional || true
-lm_require_cmd "preflight_check" "localhost" smartctl --optional || true
-lm_require_cmd "preflight_check" "localhost" nvme --optional || true
-lm_require_cmd "preflight_check" "localhost" mail --optional || true
-lm_require_cmd "preflight_check" "localhost" timeout --optional || true
-
 
 # Required commands
 REQ_CMDS=(awk sed grep df ssh)
@@ -66,6 +51,10 @@ main(){
       miss_opt_list+="$c,"
     fi
   done
+
+  if [ "$missing_req" -gt 0 ] || [ "$missing_opt" -gt 0 ]; then
+    echo "preflight_check deps missing required=[${miss_req_list%,}] optional=[${miss_opt_list%,}]" >> "$LM_LOGFILE"
+  fi
 
   # Check state/log dirs are writable
   local writable_state=1 writable_logs=1

--- a/summarize.txt
+++ b/summarize.txt
@@ -344,3 +344,7 @@ RPM packaging exists under `packaging/rpm/` (spec + systemd service/timer files)
 - tests: fix ShellCheck SC2016 in `tests/ssh_opts_validation_test.sh` by expressing unsafe command-substitution fixtures as escaped literals in double quotes.
 - status: add `--match-mode contains|exact|regex` for `--host`/`--monitor` filters across compact/verbose/JSON status paths; include test coverage for exact/regex matching and invalid-regex exit behavior.
 - dx: add `make install-githooks` target (listed in `make help`) and test idempotency with `tests/install_githooks_make_target_test.sh`.
+
+## 2026-02-16
+- preflight_check: remove per-dependency `lm_require_cmd` summary emissions so preflight now emits a single actionable summary line per run; move dependency detail lists to `LM_LOGFILE`.
+- tests: extend `tests/preflight_missing_ssh_test.sh` to assert single-line summary output and set `LINUX_MAINT_LIB` explicitly for stable repo-mode execution.

--- a/tests/preflight_missing_ssh_test.sh
+++ b/tests/preflight_missing_ssh_test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 
 export LM_MODE=repo
+export LINUX_MAINT_LIB="$ROOT_DIR/lib/linux_maint.sh"
 export LM_LOG_DIR="$ROOT_DIR/.logs"
 mkdir -p "$LM_LOG_DIR"
 
@@ -17,6 +18,7 @@ set -e
 printf "%s\n" "$out" | grep -q "monitor=preflight_check"
 printf "%s\n" "$out" | grep -q "status=UNKNOWN"
 printf "%s\n" "$out" | grep -q "reason=missing_dependency"
+[ "$(printf "%s\n" "$out" | grep -c '^monitor=' || true)" -eq 1 ]
 [ "$rc" -eq 3 ]
 
 unset LM_FORCE_MISSING_DEPS


### PR DESCRIPTION
### Motivation
- Preflight emitted per-dependency `monitor=` summary lines which clutter the summary contract and make downstream parsing and CI checks noisy.
- The intent is to keep the summary contract compact (one actionable line per monitor) and move verbose dependency details to the monitor log for operator troubleshooting.
- Update roadmap/docs to reflect the reduced noise and test coverage for this behavior.

### Description
- Stop emitting early per-dependency summary lines by removing the `lm_require_cmd` calls from `monitors/preflight_check.sh` and instead aggregate missing dependency lists and write them to `LM_LOGFILE`.
- Preserve the single actionable `lm_summary "preflight_check" ...` line that reports overall status/reason/counts in `monitors/preflight_check.sh` so contract consumers get one short line.
- Extend `tests/preflight_missing_ssh_test.sh` to set `LINUX_MAINT_LIB` for stable repo-mode execution and assert exactly one `monitor=` summary line is emitted when `ssh` is forced missing.
- Update `ToDoList.txt` (mark P0.3 DONE) and append a high-level note to `summarize.txt` describing the change.

### Testing
- Ran `SUMMARY_CONTRACT_MONITORS='preflight_check.sh' bash tests/summary_contract.sh` which reported the monitor emitted one summary line and passed.
- Ran `bash tests/preflight_missing_ssh_test.sh` which verifies `status=UNKNOWN`, `reason=missing_dependency`, and that exactly one `monitor=` summary line is present, and the test passed.
- Performed a syntax check with `bash -n monitors/preflight_check.sh tests/preflight_missing_ssh_test.sh` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992c2eb62d8833281df8ccd67de8033)